### PR TITLE
if version does not exist skip download

### DIFF
--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -687,6 +687,8 @@ def download_diffs_async(mc, project_directory, file_path, versions):
     fetch_files = []
 
     for version in versions:
+        if version not in file_history["history"]:
+            continue  # skip if version does not exist in history
         version_data = file_history["history"][version]
         if "diff" not in version_data:
             continue  # skip if there is no diff in history


### PR DESCRIPTION
In this PR MerginMaps/qgis-plugin#546 the plugin might ask for diff from the project version where the file was not yet present. That causes a crash here. With this fix if the version does not exist it is skipped. 

Example: File `a.gpkg` was added in `v7` of project. Plugin requests changesets for `v5` for files, but the client could not find the changeset for file and that version and crashed.  