### PR TITLE
Do not use paginated versions endpoint

### DIFF
--- a/mergin/cli.py
+++ b/mergin/cli.py
@@ -7,7 +7,7 @@ but the tool is not available, you may need to fix your PATH (e.g. add ~/.local/
 pip puts these tools).
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, date
 import click
 import json
 import os
@@ -143,7 +143,7 @@ def _print_unhandled_exception():
 
 
 @click.group(
-    epilog=f"Copyright (C) 2019-2021 Lutra Consulting\n\n(mergin-py-client v{__version__} / pygeodiff v{GeoDiff().version()})"
+    epilog=f"Copyright (C) 2019-{date.today().year} Lutra Consulting\n\n(mergin-py-client v{__version__} / pygeodiff v{GeoDiff().version()})"
 )
 @click.option(
     "--url",
@@ -481,9 +481,9 @@ def show_version(ctx, version):
         return
     directory = os.getcwd()
     mp = MerginProject(directory)
-    project_path = mp.project_full_name()
+    project_id = mp.project_id()
     # TODO: handle exception when version not found
-    version_info_dict = mc.project_version_info(project_path, version)[0]
+    version_info_dict = mc.project_version_info(project_id, version)
     click.secho("Project: " + version_info_dict["namespace"] + "/" + version_info_dict["project_name"])
     click.secho("Version: " + version_info_dict["name"] + " by " + version_info_dict["author"])
     click.secho("Time:    " + version_info_dict["created"])

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -984,13 +984,10 @@ class MerginClient:
 
         return pull_changes, push_changes, push_changes_summary
 
-    def project_version_info(self, project_path, version):
+    def project_version_info(self, project_id, version):
         """Returns JSON with detailed information about a single project version"""
-        params = {"version_id": version}
-        params = {"page": version, "per_page": 1, "descending": False}
-        resp = self.get(f"/v1/project/versions/paginated/{project_path}", params)
-        j = json.load(resp)
-        return j["versions"]
+        resp = self.get(f"/v1/project/version/{project_id}/{version}")
+        return json.load(resp)
 
     def project_file_history_info(self, project_path, file_path):
         """Returns JSON with full history of a single file within a project"""

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -225,10 +225,9 @@ def test_create_remote_project_from_local(mc):
     assert project_info["namespace"] == API_USER
     assert project_info["id"] == source_mp.project_id()
 
-    versions = mc.project_versions(project)
-    assert len(versions) == 1
-    assert versions[0]["name"] == "v1"
-    assert any(f for f in versions[0]["changes"]["added"] if f["path"] == "test.qgs")
+    version = mc.project_version_info(project_info.get("id"), "v1")
+    assert version["name"] == "v1"
+    assert any(f for f in version["changes"]["added"] if f["path"] == "test.qgs")
 
     # check we can fully download remote project
     mc.download_project(project, download_dir)
@@ -306,13 +305,9 @@ def test_push_pull_changes(mc):
     assert generate_checksum(os.path.join(project_dir, f_updated)) == f_remote_checksum
     assert project_info["id"] == mp.project_id()
     assert len(project_info["files"]) == len(mp.inspect_files())
-    project_versions = mc.project_versions(project)
-    assert len(project_versions) == 2
-    f_change = next(
-        (f for f in project_versions[-1]["changes"]["updated"] if f["path"] == f_updated),
-        None,
-    )
-    assert "origin_checksum" not in f_change  # internal client info
+    project_version = mc.project_version_info(project_info["id"], "v2")
+    updated_file = [f for f in project_version["changes"]["updated"] if f["path"] == f_updated][0]
+    assert "origin_checksum" not in updated_file  # internal client info
 
     # test parallel changes
     with open(os.path.join(project_dir_2, f_updated), "w") as f:
@@ -2019,7 +2014,7 @@ def test_report(mc):
             ]
         )
         assert headers in content
-        assert "base.gpkg,simple,test_plugin" in content
+        assert f"base.gpkg,simple,{API_USER}" in content
         assert "v3,update,,,2" in content
         # files not edited are not in reports
         assert "inserted_1_A.gpkg" not in content
@@ -2164,7 +2159,7 @@ def test_version_info(mc):
     project = API_USER + "/" + test_project
     project_dir = os.path.join(TMP_DIR, test_project)  # primary project dir
     test_gpkg = "test.gpkg"
-    file_path = os.path.join(project_dir, "test.gpkg")
+    file_path = os.path.join(project_dir, test_gpkg)
 
     cleanup(mc, project, [project_dir])
 
@@ -2177,8 +2172,8 @@ def test_version_info(mc):
 
     shutil.copy(os.path.join(TEST_DATA_DIR, "inserted_1_A_mod.gpkg"), file_path)
     mc.push_project(project_dir)
-
-    info = mc.project_version_info(project, 2)[0]
+    project_info = mc.project_info(project)
+    info = mc.project_version_info(project_info.get("id"), "v2")
     assert info["namespace"] == API_USER
     assert info["project_name"] == test_project
     assert info["name"] == "v2"
@@ -2345,9 +2340,14 @@ def test_project_metadata(mc):
 
     # copy metadata in old format
     os.makedirs(os.path.join(project_dir, ".mergin"), exist_ok=True)
-    project_metadata = os.path.join(project_dir, ".mergin", "mergin.json")
     metadata_file = os.path.join(project_dir, "old_metadata.json")
-    shutil.copyfile(metadata_file, project_metadata)
+    # rewrite metadata nemespace to prevent failing tests with other user than test_plugin
+    with open(metadata_file, 'r') as f:
+        metadata = json.load(f)
+    metadata['name'] = f"{API_USER}/{test_project}"
+    project_metadata_file = os.path.join(project_dir, ".mergin", "mergin.json")
+    with open(project_metadata_file, 'w') as f:
+        json.dump(metadata, f, indent=2)
 
     # verify we have correct metadata
     mp = MerginProject(project_dir)
@@ -2358,7 +2358,12 @@ def test_project_metadata(mc):
 
     # copy metadata in new format
     metadata_file = os.path.join(project_dir, "new_metadata.json")
-    shutil.copyfile(metadata_file, project_metadata)
+    # rewrite metadata nemespace to prevent failing tests with other user than test_plugin
+    with open(metadata_file, 'r') as f:
+        metadata = json.load(f)
+    metadata['namespace'] = API_USER
+    with open(project_metadata_file, 'w') as f:
+        json.dump(metadata, f, indent=2)
 
     # verify we have correct metadata
     mp = MerginProject(project_dir)
@@ -2634,7 +2639,6 @@ def test_editor_push(mc: MerginClient, mc2: MerginClient):
 
 def test_error_push_already_named_project(mc: MerginClient):
     test_project = "test_push_already_existing"
-    project = API_USER + "/" + test_project
     project_dir = os.path.join(TMP_DIR, test_project)
 
     with pytest.raises(ClientError) as e:
@@ -2642,7 +2646,7 @@ def test_error_push_already_named_project(mc: MerginClient):
     assert e.value.detail == "Project with the same name already exists"
     assert e.value.http_error == 409
     assert e.value.http_method == "POST"
-    assert e.value.url == f"{mc.url}v1/project/test_plugin"
+    assert e.value.url == f"{mc.url}v1/project/{API_USER}"
 
 
 def test_error_projects_limit_hit(mcStorage: MerginClient):

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -2342,11 +2342,11 @@ def test_project_metadata(mc):
     os.makedirs(os.path.join(project_dir, ".mergin"), exist_ok=True)
     metadata_file = os.path.join(project_dir, "old_metadata.json")
     # rewrite metadata nemespace to prevent failing tests with other user than test_plugin
-    with open(metadata_file, 'r') as f:
+    with open(metadata_file, "r") as f:
         metadata = json.load(f)
-    metadata['name'] = f"{API_USER}/{test_project}"
+    metadata["name"] = f"{API_USER}/{test_project}"
     project_metadata_file = os.path.join(project_dir, ".mergin", "mergin.json")
-    with open(project_metadata_file, 'w') as f:
+    with open(project_metadata_file, "w") as f:
         json.dump(metadata, f, indent=2)
 
     # verify we have correct metadata
@@ -2359,10 +2359,10 @@ def test_project_metadata(mc):
     # copy metadata in new format
     metadata_file = os.path.join(project_dir, "new_metadata.json")
     # rewrite metadata nemespace to prevent failing tests with other user than test_plugin
-    with open(metadata_file, 'r') as f:
+    with open(metadata_file, "r") as f:
         metadata = json.load(f)
-    metadata['namespace'] = API_USER
-    with open(project_metadata_file, 'w') as f:
+    metadata["namespace"] = API_USER
+    with open(project_metadata_file, "w") as f:
         json.dump(metadata, f, indent=2)
 
     # verify we have correct metadata


### PR DESCRIPTION
Resolves #214 

Changes:
- CLI: update show version command to call project_version_info object
- CLIENT: upgrade project_version_info api call to use get byt version name endpoint instead of paginated version
- TEST: don't use paginated endpoint in tests
- TEST: make tests runnable with other username, than test_plugin 

Fix :bug: 
- There was Error in CLI, If you asked version number (e.g. v1) ```Detail: Wrong type, expected 'integer' for query parameter 'page'``` - show-version was not running properly.

Minor:
- add year to copyright :)

Related to: https://github.com/MerginMaps/server/pull/275/files
