### PR TITLE
Cleanup references to previous repository name of python-api-client

### DIFF
--- a/mergin/cli.py
+++ b/mergin/cli.py
@@ -143,7 +143,7 @@ def _print_unhandled_exception():
 
 
 @click.group(
-    epilog=f"Copyright (C) 2019-{date.today().year} Lutra Consulting\n\n(mergin-py-client v{__version__} / pygeodiff v{GeoDiff().version()})"
+    epilog=f"Copyright (C) 2019-{date.today().year} Lutra Consulting\n\n(python-api-client v{__version__} / pygeodiff v{GeoDiff().version()})"
 )
 @click.option(
     "--url",

--- a/mergin/cli.py
+++ b/mergin/cli.py
@@ -661,6 +661,7 @@ def reset(ctx):
     except Exception as e:
         _print_unhandled_exception()
 
+
 @cli.command()
 @click.argument("project")
 @click.option("--json", is_flag=True, default=False, help="Output in JSON format")
@@ -680,7 +681,7 @@ def list_files(ctx, project, json):
     else:
         click.echo("Fetched {} files .".format(len(project_files)))
         for file in project_files:
-            click.echo("  {:40}\t{:6.1f} MB".format(file['path'], file["size"] / (1024 * 1024)))
+            click.echo("  {:40}\t{:6.1f} MB".format(file["path"], file["size"] / (1024 * 1024)))
 
 
 if __name__ == "__main__":

--- a/mergin/client_pull.py
+++ b/mergin/client_pull.py
@@ -786,7 +786,7 @@ def download_files_async(
     mp.log.info(f"Got project info. version {project_info['version']}")
 
     # set temporary directory for download
-    temp_dir = tempfile.mkdtemp(prefix="mergin-py-client-")
+    temp_dir = tempfile.mkdtemp(prefix="python-api-client-")
 
     if output_paths is None:
         output_paths = []

--- a/mergin/client_push.py
+++ b/mergin/client_push.py
@@ -124,7 +124,7 @@ def push_project_async(mc, directory):
     changes = filter_changes(mc, project_info, changes)
     mp.log.debug("push changes:\n" + pprint.pformat(changes))
 
-    tmp_dir = tempfile.TemporaryDirectory(prefix="mergin-py-client-")
+    tmp_dir = tempfile.TemporaryDirectory(prefix="python-api-client-")
 
     # If there are any versioned files (aka .gpkg) that are not updated through a diff,
     # we need to make a temporary copy somewhere to be sure that we are uploading full content.

--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -162,7 +162,7 @@ class MerginProject:
 
         Raises ClientError if project id is not present in the project metadata. This should
         only happen with projects downloaded with old client, before February 2023,
-        see https://github.com/MerginMaps/mergin-py-client/pull/154
+        see https://github.com/MerginMaps/python-api-client/pull/154
         """
         self._read_metadata()
 
@@ -810,7 +810,7 @@ class MerginProject:
 
         self.log.info("resolving unfinished pull")
 
-        temp_dir = tempfile.mkdtemp(prefix="mergin-py-client-")
+        temp_dir = tempfile.mkdtemp(prefix="python-api-client-")
 
         for root, dirs, files in os.walk(self.unfinished_pull_dir):
             for file_name in files:

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -803,7 +803,7 @@ def test_available_storage_validation(mcStorage):
 def test_available_storage_validation2(mc, mc2):
     """
     Testing of storage limit - should not be applied for user pushing changes into project with different namespace.
-    This should cover the exception of mergin-py-client that a user can push changes to someone else's project regardless
+    This should cover the exception of python-api-client that a user can push changes to someone else's project regardless
     the user's own storage limitation. Of course, other limitations are still applied (write access, owner of
     a modified project has to have enough free storage).
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 setup(
     name='mergin-client',
     version='0.9.2',
-    url='https://github.com/MerginMaps/mergin-py-client',
+    url='https://github.com/MerginMaps/python-api-client',
     license='MIT',
     author='Lutra Consulting Ltd.',
     author_email='info@merginmaps.com',


### PR DESCRIPTION
Changes all previous reference to the current repository to `python-api-client`instead of `mergin-py-client`

No  functional changes