### PR TITLE
Implementing testing api for storage change to limits tests

### DIFF
--- a/mergin/client.py
+++ b/mergin/client.py
@@ -668,7 +668,6 @@ class MerginClient:
                 order_params=order_params,
                 only_public=only_public,
             )
-            print(resp["projects"])
             fetched_projects += len(resp["projects"])
             count = resp["count"]
             projects += resp["projects"]

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -236,7 +236,7 @@ class MerginClient:
             data = json.dumps(data, cls=DateTimeEncoder).encode("utf-8")
         request = urllib.request.Request(url, data, headers, method="POST")
         return self._do_request(request)
-    
+
     def patch(self, path, data=None, headers={}):
         url = urllib.parse.urljoin(self.url, urllib.parse.quote(path))
         if headers.get("Content-Type", None) == "application/json":

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -236,6 +236,13 @@ class MerginClient:
             data = json.dumps(data, cls=DateTimeEncoder).encode("utf-8")
         request = urllib.request.Request(url, data, headers, method="POST")
         return self._do_request(request)
+    
+    def patch(self, path, data=None, headers={}):
+        url = urllib.parse.urljoin(self.url, urllib.parse.quote(path))
+        if headers.get("Content-Type", None) == "application/json":
+            data = json.dumps(data, cls=DateTimeEncoder).encode("utf-8")
+        request = urllib.request.Request(url, data, headers, method="PATCH")
+        return self._do_request(request)
 
     def is_server_compatible(self):
         """
@@ -661,6 +668,7 @@ class MerginClient:
                 order_params=order_params,
                 only_public=only_public,
             )
+            print(resp["projects"])
             fetched_projects += len(resp["projects"])
             count = resp["count"]
             projects += resp["projects"]


### PR DESCRIPTION
This is first usage of testing API for changing storage limits and projects count. Test for storage and project limit hit are now using new api. There is also ```test_available_storage_validation2``` but no validation is performed here (we need to name or remove in future). 

Other :heavy_plus_sign: 
- add patch to mergin client