### PR TITLE
Adding MonthlyContributorsError

### DIFF
--- a/mergin/common.py
+++ b/mergin/common.py
@@ -14,6 +14,7 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 class ErrorCode(Enum):
     ProjectsLimitHit = "ProjectsLimitHit"
     StorageLimitHit = "StorageLimitHit"
+    MonthlyContributorsError = "MonthlyContributorsError"
 
 
 class ClientError(Exception):


### PR DESCRIPTION
In order to implement new dialog for QGIS plugin, we need to add MonthlyContributorsError to pyApi.