### PR TITLE
Remove deprecated check for server compatibility via the list of endpoints

### DIFF
--- a/mergin/cli.py
+++ b/mergin/cli.py
@@ -95,9 +95,7 @@ def pretty_summary(summary):
 def get_token(url, username, password):
     """Get authorization token for given user and password."""
     mc = MerginClient(url)
-    if not mc.is_server_compatible():
-        click.secho(str("This client version is incompatible with server, try to upgrade"), fg="red")
-        return None
+
     try:
         session = mc.login(username, password)
     except LoginError as e:

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -244,52 +244,6 @@ class MerginClient:
         request = urllib.request.Request(url, data, headers, method="PATCH")
         return self._do_request(request)
 
-    def is_server_compatible(self):
-        """
-        Test whether version of the server meets the required set of endpoints.
-
-        :returns: client compatible with server
-        rtype: Boolean
-        """
-        resp = self.get("/ping")
-        data = json.load(resp)
-        if "endpoints" not in data:
-            return False
-        endpoints = data["endpoints"]
-
-        client_endpoints = {
-            "data_sync": {
-                "GET": ["/project/raw/{namespace}/{project_name}"],
-                "POST": [
-                    "/project/push/cancel/{transaction_id}",
-                    "/project/push/finish/{transaction_id}",
-                    "/project/push/{namespace}/{project_name}",
-                    # "/project/push/chunk/{transaction_id}/{chunk_id}" # issue in server
-                ],
-            },
-            "project": {
-                "DELETE": ["/project/{namespace}/{project_name}"],
-                "GET": [
-                    "/project",
-                    "/project/{namespace}/{project_name}",
-                    "/project/version/{namespace}/{project_name}",
-                ],
-                "POST": ["/project/{namespace}"],
-            },
-            "user": {"POST": ["/auth/login"]},
-        }
-
-        for k, v in client_endpoints.items():
-            if k not in endpoints:
-                return False
-            for method, url_list in v.items():
-                if method not in endpoints[k]:
-                    return False
-                for url in url_list:
-                    if url not in endpoints[k][method]:
-                        return False
-        return True
-
     def login(self, login, password):
         """
         Authenticate login credentials and store session token

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -1058,11 +1058,6 @@ def test_logging(mc):
     del os.environ["MERGIN_CLIENT_LOG"]
 
 
-def test_server_compatibility(mc):
-    """Test server compatibility."""
-    assert mc.is_server_compatible()
-
-
 def create_versioned_project(mc, project_name, project_dir, updated_file, remove=True, overwrite=False):
     project = API_USER + "/" + project_name
     cleanup(mc, project, [project_dir])


### PR DESCRIPTION
This check has been forgotten for some time now and blocks us from cleaning up the `/ping` response.

The PR removes it altogether as it had no use now 🙃 