### PR TITLE
Cleanup: Remove deprecated function and improve error handling

### DIFF
--- a/mergin/client.py
+++ b/mergin/client.py
@@ -343,16 +343,8 @@ class MerginClient:
 
         Returns response from server as JSON dict or None if endpoint is not found
         """
-
-        try:
-            response = self.get(f"/v1/workspace/{workspace_id}/service")
-        except ClientError as e:
-            e.extra = f"Unable to query for /workspace/{workspace_id}/service endpoint"
-            raise e
-
-        response = json.loads(response.read())
-
-        return response
+        resp = self.get(f"/v1/workspace/{workspace_id}/service")
+        return json.loads(resp)
 
     def server_type(self):
         """

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -336,24 +336,6 @@ class MerginClient:
             return None  # not authenticated
         return self._user_info["username"]
 
-    def user_service(self):
-        """
-        Requests information about user from /user/service endpoint if such exists in self.url server.
-
-        Returns response from server as JSON dict or None if endpoint is not found
-        This can be removed once our SaaS server is upgraded to support workspaces
-        """
-
-        try:
-            response = self.get("/v1/user/service")
-        except ClientError as e:
-            self.log.debug("Unable to query for /user/service endpoint")
-            return
-
-        response = json.loads(response.read())
-
-        return response
-
     def workspace_service(self, workspace_id):
         """
         This Requests information about a workspace service from /workspace/{id}/service endpoint,
@@ -365,8 +347,8 @@ class MerginClient:
         try:
             response = self.get(f"/v1/workspace/{workspace_id}/service")
         except ClientError as e:
-            self.log.debug(f"Unable to query for /workspace/{workspace_id}/service endpoint")
-            return
+            e.extra = f"Unable to query for /workspace/{workspace_id}/service endpoint"
+            raise e
 
         response = json.loads(response.read())
 


### PR DESCRIPTION
This PR contain two cleanup

* Remove unused user_service since get_user_service was deprecated and return http 400 
see https://github.com/MerginMaps/server-private/blob/7edf64b43b04bf017c8c555f913f6d8c3b0d7441/server/src/service/api.yaml#L42
* Handle error in  `mc.workspace_service` by re raising a ClientError


Needed to cleanup in the plugin PR https://github.com/MerginMaps/qgis-plugin/pull/650