### PR TITLE
Fail in last PR regarding the use of json module

### DIFF
--- a/mergin/client.py
+++ b/mergin/client.py
@@ -344,7 +344,7 @@ class MerginClient:
         Returns response from server as JSON dict or None if endpoint is not found
         """
         resp = self.get(f"/v1/workspace/{workspace_id}/service")
-        return json.loads(resp)
+        return json.load(resp)
 
     def workspace_usage(self, workspace_id):
         """

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -2754,3 +2754,32 @@ def test_error_monthly_contributors_limit_hit(mcStorage: MerginClient):
     assert e.value.http_method == "POST"
     assert e.value.url == f"{mcStorage.url}v1/project/push/testpluginstorage/{test_project}"
     assert e.value.server_response.get("contributors_quota") == 0
+
+
+def test_workspace_requests(mc2: MerginClient):
+    test_project = "test_permissions"
+    test_project_fullname = API_USER2 + "/" + test_project
+
+    project_info = mc2.project_info(test_project_fullname)
+    ws_id = project_info.get("workspace_id")
+
+    usage =  mc2.workspace_usage(ws_id)
+    # Check type and common value
+    assert type(usage) == dict
+    assert usage["api"]["allowed"] == True
+    assert usage["history"]["quota"] == 214748364800
+    assert usage["history"]["usage"] == 0
+
+    service  = mc2.workspace_service(ws_id)
+    # Check type and common value
+    assert type(service) == dict
+    assert service["action_required"] == False
+    assert service["plan"]
+    assert service["plan"]["is_paid_plan"] == False
+    assert service["plan"]["product_id"] == None
+    assert service["plan"]["type"] == 'custom'
+    assert service["subscription"] == None
+
+
+
+

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -2763,23 +2763,19 @@ def test_workspace_requests(mc2: MerginClient):
     project_info = mc2.project_info(test_project_fullname)
     ws_id = project_info.get("workspace_id")
 
-    usage =  mc2.workspace_usage(ws_id)
+    usage = mc2.workspace_usage(ws_id)
     # Check type and common value
     assert type(usage) == dict
     assert usage["api"]["allowed"] == True
     assert usage["history"]["quota"] == 214748364800
     assert usage["history"]["usage"] == 0
 
-    service  = mc2.workspace_service(ws_id)
+    service = mc2.workspace_service(ws_id)
     # Check type and common value
     assert type(service) == dict
     assert service["action_required"] == False
     assert service["plan"]
     assert service["plan"]["is_paid_plan"] == False
     assert service["plan"]["product_id"] == None
-    assert service["plan"]["type"] == 'custom'
+    assert service["plan"]["type"] == "custom"
     assert service["subscription"] == None
-
-
-
-


### PR DESCRIPTION
There is a typo in my last PR regarding the use of json module 

I used `json.loads` with a `s` instead of `json.load` that support de serializing python object and not string

Every use of workspace_service failed in the plugin because of that