### PR TITLE
Proposal for new commands groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ working directory:
 
 1. get status of the project (check if there are any local/remote changes)
    ```
-   $ mergin status
+   $ mergin project status
    ```
 2. pull changes from Mergin Maps service
    ```
@@ -141,6 +141,7 @@ If you plan to run `mergin` command multiple times and you wish to avoid logging
 you can use "login" command to get authorization token.
 It will ask for password and then output environment variable with auth token. The returned token
 is not permanent - it will expire after several hours.
+
 ```bash
 $ mergin --username john login
 Password: topsecret
@@ -150,17 +151,18 @@ export MERGIN_AUTH="Bearer ......."
 In Windows:
 SET MERGIN_AUTH=Bearer .......
 ```
+
 When setting the variable in Windows you do not quote the value.
 
 When the MERGIN_AUTH env variable is set (or passed with `--auth-token` command line argument),
 it is possible to run other commands without specifying username/password.
-
 
 ## Development
 
 ### Installing deps
 
 Python 3.7+ required. Create `mergin/deps` folder where [geodiff](https://github.com/MerginMaps/geodiff) lib is supposed to be and install dependencies:
+
 ```bash
     rm -r mergin/deps
     mkdir mergin/deps
@@ -168,7 +170,15 @@ Python 3.7+ required. Create `mergin/deps` folder where [geodiff](https://github
     pip install pygeodiff --target=mergin/deps
 ```
 
+To run `cli` from source code, install the package in editable mode:
+
+```bash
+python setup.py dist
+cd dist && pip install {PACKAGE}.gz
+```
+
 For using mergin client with its dependencies packaged locally run:
+
 ```bash
     pip install wheel
     python3 setup.py sdist bdist_wheel
@@ -179,6 +189,7 @@ For using mergin client with its dependencies packaged locally run:
 ```
 
 ### Tests
+
 For running test do:
 
 ```bash

--- a/mergin/cli.py
+++ b/mergin/cli.py
@@ -153,7 +153,7 @@ def _print_unhandled_exception():
 @click.option("--username", envvar="MERGIN_USERNAME")
 @click.option("--password", cls=OptionPasswordIfUser, prompt=True, hide_input=True, envvar="MERGIN_PASSWORD")
 @click.pass_context
-def cli(ctx, version, url, auth_token, username, password):
+def cli(ctx, url, auth_token, username, password):
     """
     Command line interface for the Mergin Maps client module.
     For user authentication on server there are two options:
@@ -526,7 +526,7 @@ def history(ctx, path):
 @click.argument("path")
 @click.argument("version")
 @click.pass_context
-def show_file_changeset(ctx, path, version):
+def changeset(ctx, path, version):
     """Displays file changes."""
     mc = ctx.obj["client"]
     if mc is None:
@@ -744,6 +744,12 @@ def members():
     "Workspace members management"
     pass
 
+@members.command(name="list")
+@click.pass_context
+def members_list():
+    "List workspace members"
+    pass
+
 @members.command()
 @click.pass_context
 def get():
@@ -756,10 +762,10 @@ def add():
     "Add workspace member"
     pass
 
-@workspace.command()
+@members.command()
 @click.pass_context
 def update():
-    "Create workspace"
+    "Update workspace member"
     pass
 
 @members.command()

--- a/mergin/cli.py
+++ b/mergin/cli.py
@@ -153,7 +153,7 @@ def _print_unhandled_exception():
 @click.option("--username", envvar="MERGIN_USERNAME")
 @click.option("--password", cls=OptionPasswordIfUser, prompt=True, hide_input=True, envvar="MERGIN_PASSWORD")
 @click.pass_context
-def cli(ctx, url, auth_token, username, password):
+def cli(ctx, version, url, auth_token, username, password):
     """
     Command line interface for the Mergin Maps client module.
     For user authentication on server there are two options:
@@ -164,9 +164,11 @@ def cli(ctx, url, auth_token, username, password):
 
     Run `mergin --username <your_user> login` to see how to set the token variable manually.
     """
+    if (version):
+        click.secho(f"v{__version__} / pygeodiff v{GeoDiff().version()}")
+        return
     mc = get_client(url=url, auth_token=auth_token, username=username, password=password)
     ctx.obj = {"client": mc}
-
 
 @cli.command()
 @click.pass_context
@@ -182,8 +184,17 @@ def login(ctx):
             hint = f'To set the MERGIN_AUTH variable run:\nexport MERGIN_AUTH="{token}"'
         click.secho(hint)
 
+@cli.group()
+def project():
+    "Commands related to projects"
+    pass
 
-@cli.command()
+@cli.group()
+def file():
+    "Commands related to files stored in project"
+    pass
+
+@project.command()
 @click.argument("project")
 @click.option("--public", is_flag=True, default=False, help="Public project, visible to everyone")
 @click.option(
@@ -212,7 +223,7 @@ def create(ctx, project, public, from_dir):
         _print_unhandled_exception()
 
 
-@cli.command()
+@project.command(name="list")
 @click.argument("namespace")
 @click.option(
     "--name",
@@ -227,7 +238,7 @@ def create(ctx, project, public, from_dir):
     "Available attrs: namespace, name, created, updated, disk_usage, creator",
 )
 @click.pass_context
-def list_projects(ctx, name, namespace, order_params):
+def project_list(ctx, name, namespace, order_params):
     """List projects on the server."""
 
     mc = ctx.obj["client"]
@@ -244,7 +255,7 @@ def list_projects(ctx, name, namespace, order_params):
         )
 
 
-@cli.command()
+@project.command()
 @click.argument("project")
 @click.argument("directory", type=click.Path(), required=False)
 @click.option("--version", default=None, help="Version of project to download")
@@ -276,7 +287,7 @@ def download(ctx, project, directory, version):
         _print_unhandled_exception()
 
 
-@cli.command()
+@project.command()
 @click.argument("project")
 @click.argument("usernames", nargs=-1)
 @click.option("--permissions", help="permissions to be granted to project (reader, writer, owner)")
@@ -290,7 +301,7 @@ def share_add(ctx, project, usernames, permissions):
     mc.add_user_permissions_to_project(project, usernames, permissions)
 
 
-@cli.command()
+@project.command()
 @click.argument("project")
 @click.argument("usernames", nargs=-1)
 @click.pass_context
@@ -303,7 +314,7 @@ def share_remove(ctx, project, usernames):
     mc.remove_user_permissions_from_project(project, usernames)
 
 
-@cli.command()
+@project.command()
 @click.argument("project")
 @click.pass_context
 def share(ctx, project):
@@ -331,12 +342,12 @@ def share(ctx, project):
             click.echo("{:20}\t{:20}".format(username, "reader"))
 
 
-@cli.command()
+@file.command("download")
 @click.argument("filepath")
 @click.argument("output")
 @click.option("--version", help="Project version tag, for example 'v3'")
 @click.pass_context
-def download_file(ctx, filepath, output, version):
+def file_download(ctx, filepath, output, version):
     """
     Download project file at specified version. `project` needs to be a combination of namespace/project.
     If no version is given, the latest will be fetched.
@@ -368,7 +379,7 @@ def num_version(name):
     return int(name.lstrip("v"))
 
 
-@cli.command()
+@project.command()
 @click.pass_context
 def status(ctx):
     """Show all changes in project files - upstream and local."""
@@ -469,10 +480,10 @@ def pull(ctx):
         _print_unhandled_exception()
 
 
-@cli.command()
+@project.command()
 @click.argument("version")
 @click.pass_context
-def show_version(ctx, version):
+def version(ctx, version):
     """Displays information about a single version of a project. `version` is 'v1', 'v2', etc."""
     mc = ctx.obj["client"]
     if mc is None:
@@ -488,11 +499,11 @@ def show_version(ctx, version):
     pretty_diff(version_info_dict["changes"])
 
 
-@cli.command()
+@file.command()
 @click.argument("path")
 @click.pass_context
-def show_file_history(ctx, path):
-    """Displays information about a single version of a project."""
+def history(ctx, path):
+    """Displays history for file in specified path"""
     mc = ctx.obj["client"]
     if mc is None:
         return
@@ -511,12 +522,12 @@ def show_file_history(ctx, path):
         click.secho(" {:5} {:10} {}".format(version, version_data["change"], diff_info))
 
 
-@cli.command()
+@file.command()
 @click.argument("path")
 @click.argument("version")
 @click.pass_context
 def show_file_changeset(ctx, path, version):
-    """Displays information about project changes."""
+    """Displays file changes."""
     mc = ctx.obj["client"]
     if mc is None:
         return
@@ -528,7 +539,7 @@ def show_file_changeset(ctx, path, version):
     click.secho(json.dumps(info_dict, indent=2))
 
 
-@cli.command()
+@project.command()
 @click.argument("source_project_path", required=True)
 @click.argument("cloned_project_name", required=True)
 @click.argument("cloned_project_namespace", required=False)
@@ -561,7 +572,7 @@ def clone(ctx, source_project_path, cloned_project_name, cloned_project_namespac
         _print_unhandled_exception()
 
 
-@cli.command()
+@project.command()
 @click.argument("project", required=True)
 @click.pass_context
 def remove(ctx, project):
@@ -608,7 +619,7 @@ def resolve_unfinished_pull(ctx):
         _print_unhandled_exception()
 
 
-@cli.command()
+@project.command()
 @click.argument("project_path")
 @click.argument("new_project_name")
 @click.pass_context
@@ -642,7 +653,7 @@ def rename(ctx, project_path: str, new_project_name: str):
         _print_unhandled_exception()
 
 
-@cli.command()
+@project.command()
 @click.pass_context
 def reset(ctx):
     """Reset local changes in project."""
@@ -660,11 +671,11 @@ def reset(ctx):
         _print_unhandled_exception()
 
 
-@cli.command()
+@file.command("list")
 @click.argument("project")
 @click.option("--json", is_flag=True, default=False, help="Output in JSON format")
 @click.pass_context
-def list_files(ctx, project, json):
+def file_list(ctx, project, json):
     """List files in a project."""
 
     mc = ctx.obj["client"]
@@ -680,6 +691,83 @@ def list_files(ctx, project, json):
         click.echo("Fetched {} files .".format(len(project_files)))
         for file in project_files:
             click.echo("  {:40}\t{:6.1f} MB".format(file["path"], file["size"] / (1024 * 1024)))
+
+@cli.group()
+@click.pass_context
+def user():
+    """User management"""
+    pass
+
+@user.command()
+@click.pass_context
+def register():
+    "Register user"
+    pass
+
+@project.group()
+@click.pass_context
+def collaborators():
+    pass
+
+@collaborators.command(name="list")
+@click.pass_context
+def collaborators_list(ctx):
+    "List project collaborators"
+    pass
+
+@collaborators.command()
+@click.pass_context
+def add():
+    "Add project collaborator"
+    pass
+
+@collaborators.command()
+@click.pass_context
+def update():
+    "Update project collaborator"
+    pass
+
+@collaborators.command()
+@click.pass_context
+def remove():
+    "Update project collaborator"
+    pass
+
+@cli.group()
+def workspace():
+    "Workspace management"
+    pass
+
+@workspace.group()
+@click.pass_context
+def members():
+    "Workspace members management"
+    pass
+
+@members.command()
+@click.pass_context
+def get():
+    "Get workspace member"
+    pass
+
+@members.command()
+@click.pass_context
+def add():
+    "Add workspace member"
+    pass
+
+@workspace.command()
+@click.pass_context
+def update():
+    "Create workspace"
+    pass
+
+@members.command()
+@click.pass_context
+def remove():
+    "Remove workspace member"
+    pass
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Introduces new command groups which will replace "-" commands in mergin cli.

Following docs for commands:

## `mergin` command
```bash
$ mergin --help
Usage: mergin [OPTIONS] COMMAND [ARGS]...

  Command line interface for the Mergin Maps client module. For user
  authentication on server there are two options:

   1. authorization token environment variable (MERGIN_AUTH) is defined, or
   2. username and password need to be given either as environment variables
   (MERGIN_USERNAME, MERGIN_PASSWORD),  or as command options (--username,
   --password).

  Run `mergin --username <your_user> login` to see how to set the token
  variable manually.

Options:
  --url TEXT         Mergin Maps server URL. Default is:
                     https://app.merginmaps.com
  --auth-token TEXT  Mergin Maps authentication token string
  --username TEXT
  --password TEXT
  --help             Show this message and exit.

Commands:
  file                     Commands related to files stored in project
  login                    Login to the service and see how to set the...
  project                  Commands related to projects
  pull                     Fetch changes from Mergin Maps repository.
  push                     Upload local changes into Mergin Maps repository.
  resolve-unfinished-pull  Try to resolve unfinished pull.
  user                     User management
  workspace                Workspace management

  Copyright (C) 2019-2025 Lutra Consulting

  (python-api-client v0.9.4 / pygeodiff v2.0.4)
```

## `file` sub-command

:question: 
- not sure if want to move to project group?

```bash
$ mergin file --help
v0.9.4 / pygeodiff v2.0.4
Usage: mergin file [OPTIONS] COMMAND [ARGS]...

  Commands related to files stored in project

Options:
  --help  Show this message and exit.

Commands:
  changeset  Displays file changes.
  download   Download project file at specified version.
  history    Displays history for file in specified path
  list       List files in a project.
```

## `project` sub-command

```bash
$ mergin project --help
v0.9.4 / pygeodiff v2.0.4
Usage: mergin project [OPTIONS] COMMAND [ARGS]...

  Commands related to projects

Options:
  --help  Show this message and exit.

Commands:
  clone          Clone project from server.
  collaborators
  create         Create a new project on Mergin Maps server.
  download       Download last version of mergin project.
  list           List projects on the server.
  remove         Remove project from server.
  rename         Rename project in Mergin Maps repository.
  reset          Reset local changes in project.
  share          Fetch permissions to project.
  share-add      Add permissions to [users] to project.
  share-remove   Remove [users] permissions from project.
  status         Show all changes in project files - upstream and local.
  version        Displays information about a single version of a project.
```

### `project collaborators` sub-command

```bash
$ mergin project collaborators
v0.9.4 / pygeodiff v2.0.4
Usage: mergin project collaborators [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  add     Add project collaborator
  list    List project collaborators
  remove  Update project collaborator
  update  Update project collaborator
```

## `user` sub-command

:question: 
- not sure if here will be also login

```bash
$ mergin user --help
v0.9.4 / pygeodiff v2.0.4
Usage: mergin user [OPTIONS] COMMAND [ARGS]...

  User management

Options:
  --help  Show this message and exit.

Commands:
  register  Register user
```

## `workspace` sub-command

```bash
$ mergin workspace
v0.9.4 / pygeodiff v2.0.4
Usage: mergin workspace [OPTIONS] COMMAND [ARGS]...

  Workspace management

Options:
  --help  Show this message and exit.

Commands:
  members  Workspace members management
```

### `workspace members` sub-command

```bash
$ mergin workspace members
v0.9.4 / pygeodiff v2.0.4
Usage: mergin workspace members [OPTIONS] COMMAND [ARGS]...

  Workspace members management

Options:
  --help  Show this message and exit.

Commands:
  add     Add workspace member
  get     Get workspace member
  list    List workspace members
  remove  Remove workspace member
  update  Update workspace member
```

:exclamation: 

This is just proposal for future look of our nice cli tool.

:question: 

- do we want to use `list` for list commands? Unfortuanetely, it's not possible to create group (members) which can be also command.
