### PR TITLE
allow client creation without authorization

### DIFF
--- a/mergin/client.py
+++ b/mergin/client.py
@@ -146,16 +146,15 @@ class MerginClient:
             self.opener = urllib.request.build_opener(*handlers, https_handler)
         urllib.request.install_opener(self.opener)
 
-        if login or password:
-            if login and not password:
-                raise ClientError("Unable to log in: no password provided for '{}'".format(login))
-            if password and not login:
-                raise ClientError("Unable to log in: password provided but no username/email")
+        if login and not password:
+            raise ClientError("Unable to log in: no password provided for '{}'".format(login))
+        if password and not login:
+            raise ClientError("Unable to log in: password provided but no username/email")
 
-            if login and password:
-                self._auth_params = {"login": login, "password": password}
-                if not self._auth_session:
-                    self.login(login, password)
+        if login and password:
+            self._auth_params = {"login": login, "password": password}
+            if not self._auth_session:
+                self.login(login, password)
 
     def setup_logging(self):
         """Setup Mergin Maps client logging."""

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -157,10 +157,6 @@ class MerginClient:
                 if not self._auth_session:
                     self.login(login, password)
 
-        else:
-            if not self._auth_session:
-                raise ClientError("Unable to log in: no auth token provided for login")
-
     def setup_logging(self):
         """Setup Mergin Maps client logging."""
         client_log_file = os.environ.get("MERGIN_CLIENT_LOG", None)

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -2871,3 +2871,18 @@ def test_send_logs(mc: MerginClient, monkeypatch):
 
     with pytest.raises(ClientError, match="The requested URL was not found on the server"):
         mc.send_logs(logs_path)
+
+
+def test_mc_without_login():
+
+    # client without login should be able to access server config
+    mc = MerginClient(SERVER_URL)
+    config = mc.server_config()
+    assert config
+    assert isinstance(config, dict)
+    assert "server_configured" in config
+    assert config["server_configured"]
+
+    # without login should not be able to access workspaces
+    with pytest.raises(ClientError, match="The requested URL was not found on the server"):
+        mc.workspaces_list()

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -10,7 +10,6 @@ import pytest
 import pytz
 import sqlite3
 import glob
-from urllib.error import HTTPError
 
 from .. import InvalidProject
 from ..client import (
@@ -2885,5 +2884,5 @@ def test_mc_without_login():
     assert config["server_configured"]
 
     # without login should not be able to access workspaces
-    with pytest.raises(HTTPError):
+    with pytest.raises(ClientError, match="Authentication information is missing or invalid."):
         mc.workspaces_list()

--- a/mergin/test/test_client.py
+++ b/mergin/test/test_client.py
@@ -10,6 +10,7 @@ import pytest
 import pytz
 import sqlite3
 import glob
+from urllib.error import HTTPError
 
 from .. import InvalidProject
 from ..client import (
@@ -2884,5 +2885,5 @@ def test_mc_without_login():
     assert config["server_configured"]
 
     # without login should not be able to access workspaces
-    with pytest.raises(ClientError, match="The requested URL was not found on the server"):
+    with pytest.raises(HTTPError):
         mc.workspaces_list()


### PR DESCRIPTION
Allow creation of MerginClient without login.

Add test case that MC without login can get server config but cannot do much else.