### PR TITLE
Fix error handling  _do_request()

### DIFF
--- a/mergin/client.py
+++ b/mergin/client.py
@@ -231,6 +231,7 @@ class MerginClient:
 
             err_detail = None
             server_response = None
+            server_code = None
 
             if e.fp:
                 server_response = e.fp.read().decode("utf-8")
@@ -243,6 +244,7 @@ class MerginClient:
                         err_detail = json_response.get(
                             "detail", None
                         )  # `detail` should be present in MM server response
+                        server_code = json_response.get("code", None)
                     if err_detail is None:
                         err_detail = server_response
                 else:
@@ -251,7 +253,7 @@ class MerginClient:
             raise ClientError(
                 detail=err_detail,
                 url=request.get_full_url(),
-                server_code=e.code,
+                server_code=server_code,
                 server_response=server_response,
                 http_error=e.code,
                 http_method=request.get_method(),

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -229,7 +229,6 @@ class MerginClient:
             return self.opener.open(request)
         except urllib.error.HTTPError as e:
 
-            server_code = e.code
             err_detail = None
             server_response = None
 
@@ -252,7 +251,7 @@ class MerginClient:
             raise ClientError(
                 detail=err_detail,
                 url=request.get_full_url(),
-                server_code=server_code,
+                server_code=e.code,
                 server_response=server_response,
                 http_error=e.code,
                 http_method=request.get_method(),

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -230,7 +230,7 @@ class MerginClient:
         except urllib.error.HTTPError as e:
 
             server_code = e.code
-            err_detail = "Unknown error"
+            err_detail = None
             server_response = None
 
             if e.fp:

--- a/mergin/client.py
+++ b/mergin/client.py
@@ -240,7 +240,10 @@ class MerginClient:
                     or e.headers.get("Content-Type", "") == "application/json"
                 ):
                     json_response = json.loads(server_response)
-                    err_detail = json_response.get("detail", None)  # `detail` should be present in MM server response
+                    if isinstance(json_response, dict):
+                        err_detail = json_response.get(
+                            "detail", None
+                        )  # `detail` should be present in MM server response
                     if err_detail is None:
                         err_detail = server_response
                 else:


### PR DESCRIPTION
Fixes how `HTTPError` is handled in `_do_request()`.

This should fix a lot of errors in plugin and db-sync, or at least provide much better error messages for them.

Fixes MerginMaps/qgis-plugin#642 and many others