### PR TITLE
Add type check when creating a new MerginProject

### DIFF
--- a/mergin/merginproject.py
+++ b/mergin/merginproject.py
@@ -42,6 +42,8 @@ class MerginProject:
     """
 
     def __init__(self, directory):
+        if not isinstance(directory, str):
+            raise ClientError("'directory' must be a str")
         self.dir = os.path.abspath(directory)
         if not os.path.exists(self.dir):
             raise InvalidProject("Project directory does not exist")


### PR DESCRIPTION
When initializing a new `MerginProject`, directory must be a `str`. If we pass something else, like a `pathlib.Path`, we get a weird error when the logger is initialized. 